### PR TITLE
fix: paginate databricks_list_jobs across all pages

### DIFF
--- a/src/mcp_server/job_manager.py
+++ b/src/mcp_server/job_manager.py
@@ -180,56 +180,75 @@ class DatabricksJobManager:
             log_databricks_event("JOBS", "ERROR", error_msg, "ERROR")
             raise
 
-    def list_jobs(
-        self, limit: int = 25, name_filter: Optional[str] = None
-    ) -> List[JobInfo]:
+    def list_jobs(self, max_jobs: int = 1000) -> Tuple[List[JobInfo], bool]:
         """
-        List Databricks jobs with optional filtering.
+        List Databricks jobs, following the Jobs API's pagination
+        (has_more/next_page_token) across the whole workspace instead of
+        stopping after the first page.
+
+        Note: we deliberately do not use the API's `name` query param —
+        it is an exact (case-insensitive) match, not a substring search,
+        so it's unsuitable for "find a job I know exists" lookups. Callers
+        should fetch the full list and filter client-side instead.
 
         Args:
-            limit: Maximum number of jobs to return (default: 25, max: 100)
-            name_filter: Optional filter for job names (case-insensitive partial match)
+            max_jobs: Safety cap on total jobs fetched across all pages
+                      before giving up, even if more remain (default: 1000)
 
         Returns:
-            List of JobInfo objects
+            Tuple of (list of JobInfo objects, truncated) where `truncated`
+            is True if `max_jobs` was hit before the workspace's job list
+            was exhausted (i.e. results may be incomplete).
         """
         try:
-            # Limit the number of results to prevent overwhelming responses
-            limit = min(limit, 100)
+            jobs: List[JobInfo] = []
+            page_token: Optional[str] = None
+            truncated = False
 
-            params: Dict[str, Any] = {"limit": limit}
-            if name_filter:
-                params["name"] = name_filter
+            while True:
+                params: Dict[str, Any] = {"limit": min(100, max_jobs - len(jobs))}
+                if page_token:
+                    params["page_token"] = page_token
 
-            response = self._make_request("GET", "/jobs/list", params=params)
+                response = self._make_request("GET", "/jobs/list", params=params)
 
-            jobs = []
-            for job_data in response.get("jobs", []):
-                settings = job_data.get("settings", {})
-                created_time = job_data.get("created_time", 0)
+                for job_data in response.get("jobs", []):
+                    settings = job_data.get("settings", {})
+                    created_time = job_data.get("created_time", 0)
 
-                # Get last run information if available
-                last_run_state = None
-                last_run_time = None
-                if "last_run" in job_data:
-                    last_run = job_data["last_run"]
-                    last_run_state = last_run.get("state", {}).get("life_cycle_state")
-                    last_run_time = last_run.get("start_time")
+                    # Get last run information if available
+                    last_run_state = None
+                    last_run_time = None
+                    if "last_run" in job_data:
+                        last_run = job_data["last_run"]
+                        last_run_state = last_run.get("state", {}).get("life_cycle_state")
+                        last_run_time = last_run.get("start_time")
 
-                job_info = JobInfo(
-                    job_id=job_data["job_id"],
-                    name=settings.get("name", f"Job {job_data['job_id']}"),
-                    creator_email=job_data.get("creator_user_name", "unknown"),
-                    created_time=created_time,
-                    job_type=self._determine_job_type(settings),
-                    status="ACTIVE" if job_data.get("settings") else "UNKNOWN",
-                    last_run_state=last_run_state,
-                    last_run_time=last_run_time,
-                )
-                jobs.append(job_info)
+                    job_info = JobInfo(
+                        job_id=job_data["job_id"],
+                        name=settings.get("name", f"Job {job_data['job_id']}"),
+                        creator_email=job_data.get("creator_user_name", "unknown"),
+                        created_time=created_time,
+                        job_type=self._determine_job_type(settings),
+                        status="ACTIVE" if job_data.get("settings") else "UNKNOWN",
+                        last_run_state=last_run_state,
+                        last_run_time=last_run_time,
+                    )
+                    jobs.append(job_info)
 
-            log_databricks_event("JOBS", "LIST", f"Retrieved {len(jobs)} jobs")
-            return jobs
+                has_more = response.get("has_more", False)
+                page_token = response.get("next_page_token")
+
+                if len(jobs) >= max_jobs and has_more:
+                    truncated = True
+                    break
+                if not has_more or not page_token:
+                    break
+
+            log_databricks_event(
+                "JOBS", "LIST", f"Retrieved {len(jobs)} jobs (truncated: {truncated})"
+            )
+            return jobs, truncated
 
         except Exception as e:
             log_databricks_event("JOBS", "ERROR", f"Failed to list jobs: {e}", "ERROR")

--- a/src/mcp_server/mcp_server.py
+++ b/src/mcp_server/mcp_server.py
@@ -633,16 +633,28 @@ def _list_jobs(
 
         workspace_name = resolve_workspace_name(workspace)
         job_manager = get_job_manager(workspace_name)
-        fetch_limit = min(offset + limit, 100)
-        all_jobs = job_manager.list_jobs(limit=fetch_limit, name_filter=name_filter)
+        all_jobs, truncated = job_manager.list_jobs()
+        fetched_count = len(all_jobs)
+
+        if name_filter:
+            needle = name_filter.lower()
+            all_jobs = [j for j in all_jobs if needle in j.name.lower()]
+
+        truncation_notice = (
+            f"\n\n⚠️ Searched first {fetched_count} jobs before hitting the safety cap — "
+            "the workspace has more jobs than were scanned, so results may be incomplete."
+            if truncated
+            else ""
+        )
 
         if not all_jobs:
-            return "No jobs found in the Databricks workspace."
+            msg = f"No jobs found matching '{name_filter}'." if name_filter else "No jobs found in the Databricks workspace."
+            return msg + truncation_notice
 
         total = len(all_jobs)
         jobs = all_jobs[offset : offset + limit]
         if not jobs:
-            return f"No jobs at offset {offset} (total: {total})."
+            return f"No jobs at offset {offset} (total: {total})." + truncation_notice
 
         header = "| Job ID | Job Name | Type | Creator | Status | Last Run |"
         separator = "| --- | --- | --- | --- | --- | --- |"
@@ -660,6 +672,7 @@ def _list_jobs(
             + pagination_footer(
                 count=len(jobs), offset=offset, limit=limit, total=total
             )
+            + truncation_notice
         )
 
         log_mcp_event("list_jobs", "SUCCESS", f"Retrieved {len(jobs)} jobs")

--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -109,14 +109,104 @@ class TestDatabricksJobManager:
         manager = DatabricksJobManager(
             host="test-workspace.cloud.databricks.com", token="test-token"
         )
-        jobs = manager.list_jobs(limit=10)
+        jobs, truncated = manager.list_jobs()
 
+        assert not truncated
         assert len(jobs) == 1
         assert jobs[0].job_id == 123
         assert jobs[0].name == "Test Job"
         assert jobs[0].job_type == "NOTEBOOK"
         assert jobs[0].creator_email == "test@example.com"
         assert jobs[0].last_run_state == "TERMINATED"
+
+    @patch.dict(
+        "os.environ",
+        {
+            "DATABRICKS_HOST": "test-workspace.cloud.databricks.com",
+            "DATABRICKS_TOKEN": "test-token",
+        },
+    )
+    @patch("src.mcp_server.job_manager.requests.Session")
+    @patch("src.mcp_server.job_manager.log_databricks_event")
+    def test_list_jobs_follows_pagination(self, mock_log, mock_session_cls):
+        """A job beyond the first page must still be returned (regression for #88)."""
+        mock_session = Mock()
+        mock_session_cls.return_value = mock_session
+
+        def make_job(job_id):
+            return {
+                "job_id": job_id,
+                "settings": {"name": f"job-{job_id}"},
+                "creator_user_name": "test@example.com",
+                "created_time": 1640995200000,
+            }
+
+        page_1 = Mock()
+        page_1.status_code = 200
+        page_1.content = b"{}"
+        page_1.json.return_value = {
+            "jobs": [make_job(1)],
+            "has_more": True,
+            "next_page_token": "page-2-token",
+        }
+        page_2 = Mock()
+        page_2.status_code = 200
+        page_2.content = b"{}"
+        page_2.json.return_value = {
+            "jobs": [make_job(2)],
+            "has_more": False,
+        }
+        mock_session.request.side_effect = [page_1, page_2]
+
+        manager = DatabricksJobManager(
+            host="test-workspace.cloud.databricks.com", token="test-token"
+        )
+        jobs, truncated = manager.list_jobs()
+
+        assert not truncated
+        assert [j.job_id for j in jobs] == [1, 2]
+        assert mock_session.request.call_count == 2
+        second_call_params = mock_session.request.call_args_list[1].kwargs["params"]
+        assert second_call_params["page_token"] == "page-2-token"
+
+    @patch.dict(
+        "os.environ",
+        {
+            "DATABRICKS_HOST": "test-workspace.cloud.databricks.com",
+            "DATABRICKS_TOKEN": "test-token",
+        },
+    )
+    @patch("src.mcp_server.job_manager.requests.Session")
+    @patch("src.mcp_server.job_manager.log_databricks_event")
+    def test_list_jobs_reports_truncation_at_safety_cap(self, mock_log, mock_session_cls):
+        """If the safety cap is hit before has_more is False, callers must be told."""
+        mock_session = Mock()
+        mock_session_cls.return_value = mock_session
+
+        page = Mock()
+        page.status_code = 200
+        page.content = b"{}"
+        page.json.return_value = {
+            "jobs": [
+                {
+                    "job_id": 1,
+                    "settings": {"name": "job-1"},
+                    "creator_user_name": "test@example.com",
+                    "created_time": 0,
+                }
+            ],
+            "has_more": True,
+            "next_page_token": "next",
+        }
+        mock_session.request.return_value = page
+
+        manager = DatabricksJobManager(
+            host="test-workspace.cloud.databricks.com", token="test-token"
+        )
+        jobs, truncated = manager.list_jobs(max_jobs=1)
+
+        assert truncated
+        assert len(jobs) == 1
 
     @patch.dict(
         "os.environ",
@@ -332,7 +422,7 @@ class TestMCPJobTools:
                 last_run_state="TERMINATED",
             )
         ]
-        mock_manager.list_jobs.return_value = mock_jobs
+        mock_manager.list_jobs.return_value = (mock_jobs, False)
         mock_get_manager.return_value = mock_manager
 
         result = _list_jobs(limit=10, name_filter="test")
@@ -342,7 +432,7 @@ class TestMCPJobTools:
         assert "Test Job" in result
         assert "NOTEBOOK" in result
         assert "TERMINATED" in result
-        mock_manager.list_jobs.assert_called_once_with(limit=10, name_filter="test")
+        mock_manager.list_jobs.assert_called_once_with()
 
     @patch("src.mcp_server.mcp_server.get_job_manager")
     @patch("src.mcp_server.mcp_server.log_mcp_event")
@@ -473,7 +563,7 @@ class TestMCPJobTools:
     def test_list_jobs_no_results(self, mock_log, mock_get_manager):
         """Test list_jobs when no jobs are found."""
         mock_manager = Mock()
-        mock_manager.list_jobs.return_value = []
+        mock_manager.list_jobs.return_value = ([], False)
         mock_get_manager.return_value = mock_manager
 
         result = _list_jobs()


### PR DESCRIPTION
## Summary
- `JobManager.list_jobs()` stopped after a single Jobs API page (capped at 100), never following `has_more`/`next_page_token` — so jobs beyond page 1 were invisible to both full listings and `name_filter` searches.
- The API's `name` param used for `name_filter` is an exact case-insensitive match, not a substring, so a partial-name search (e.g. `"phi-sanitizer"`) would silently return nothing even for a job that existed on page 1.
- `list_jobs()` now paginates the whole workspace (capped at 1000 jobs as a safety limit) and returns `(jobs, truncated)`. `_list_jobs()` filters client-side across the full fetched set and, if the safety cap is hit, says so explicitly instead of returning a misleadingly clean "no jobs found."

Fixes #88

## Test plan
- [x] Added regression test proving a job on page 2 is returned (`test_list_jobs_follows_pagination`)
- [x] Added regression test proving the truncation warning fires when the safety cap is hit (`test_list_jobs_reports_truncation_at_safety_cap`)
- [x] Updated existing tests for the new `(jobs, truncated)` return signature
- [x] Full suite: `uv run pytest` — 132 passed