### PR TITLE
fix: get_job_details falls back to system.lakeflow on ACL-gapped jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `get_job_details` no longer fails outright when the Jobs API 400s with a
+  misleading "does not exist" for a job that's actually just ACL-gapped
+  (this connection's token lacks `CAN_VIEW`). It now falls back to
+  `system.lakeflow.jobs`/`job_tasks` for partial info (name, creator/run_as,
+  trigger type, task keys) and marks the result `partial` with an explanation,
+  instead of erroring with no information. Genuinely missing job IDs still
+  raise as before. (de-repo-artifact#90, option 3 of that issue's proposals)
+
 ## [0.2.0] - 2026-01-12
 
 ### Added

--- a/src/mcp_server/job_manager.py
+++ b/src/mcp_server/job_manager.py
@@ -17,6 +17,7 @@ from .logger import log_databricks_event, logger
 from .config import get_setting_int
 from .error_handler import with_databricks_retry
 from .workspaces import get_workspace_config, resolve_workspace_name
+from .connection_pool import get_pool, PooledConnection
 
 import requests
 
@@ -298,10 +299,120 @@ class DatabricksJobManager:
             return details
 
         except Exception as e:
+            error_str = str(e)
+            # The Jobs API returns the same 400 "does not exist" for a truly
+            # missing job_id and for a job that exists but that this
+            # connection's identity lacks CAN_VIEW on (see de-repo-artifact
+            # #89/#90) - the two are indistinguishable from the error alone.
+            # Try to recover partial info from system.lakeflow before giving up.
+            if "HTTP 400" in error_str and "does not exist" in error_str.lower():
+                fallback = self._get_job_details_from_system_tables(job_id)
+                if fallback is not None:
+                    log_databricks_event(
+                        "JOBS",
+                        "DETAILS_PARTIAL",
+                        f"Job {job_id} not visible via Jobs API; "
+                        "returned partial info from system.lakeflow",
+                    )
+                    return fallback
+
             log_databricks_event(
                 "JOBS", "ERROR", f"Failed to get job {job_id} details: {e}", "ERROR"
             )
             raise
+
+    def _get_job_details_from_system_tables(self, job_id: int) -> Optional[Dict[str, Any]]:
+        """
+        Best-effort fallback when /jobs/get 400s with "does not exist".
+
+        Queries system.lakeflow.jobs and system.lakeflow.job_tasks, which are
+        populated from the account-level audit/billing pipeline rather than
+        the per-job ACL this connection's token is scoped to, so they surface
+        jobs the Jobs API otherwise hides. Only name, creator/run_as, trigger
+        type, and task keys are available this way - no cluster spec, task
+        parameters, or notebook/script paths (those only come from /jobs/get).
+
+        Returns None if the job isn't found in system tables either (i.e.
+        it genuinely doesn't exist), so callers can fall back to raising the
+        original error.
+        """
+        try:
+            pool = get_pool(self.workspace_name)
+            with PooledConnection(pool) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT name, creator_id, creator_user_name, run_as,
+                           run_as_user_name, trigger_type, paused,
+                           timeout_seconds, create_time
+                    FROM system.lakeflow.jobs
+                    WHERE job_id = %s AND delete_time IS NULL
+                    ORDER BY change_time DESC
+                    LIMIT 1
+                    """,
+                    (str(job_id),),
+                )
+                row = cursor.fetchone()
+                if row is None or cursor.description is None:
+                    return None
+
+                columns = [d[0] for d in cursor.description]
+                job_row = dict(zip(columns, row))
+
+                cursor.execute(
+                    """
+                    SELECT DISTINCT task_key
+                    FROM system.lakeflow.job_tasks
+                    WHERE job_id = %s AND delete_time IS NULL
+                    """,
+                    (str(job_id),),
+                )
+                task_keys = [r[0] for r in cursor.fetchall()]
+        except Exception as e:
+            # A failure here should never mask the original /jobs/get error -
+            # log and let the caller fall back to raising it.
+            log_databricks_event(
+                "JOBS",
+                "ERROR",
+                f"system.lakeflow fallback failed for job {job_id}: {e}",
+                "ERROR",
+            )
+            return None
+
+        create_time = job_row.get("create_time")
+        task_keys = sorted(k for k in task_keys if k)
+
+        return {
+            "job_id": job_id,
+            "name": job_row.get("name") or f"Job {job_id}",
+            "created_time": str(create_time) if create_time else "Unknown",
+            "creator": job_row.get("creator_user_name") or job_row.get("creator_id") or "unknown",
+            "run_as": job_row.get("run_as_user_name") or job_row.get("run_as"),
+            "job_type": "multi_task" if len(task_keys) > 1 else "single_task",
+            "schedule": {
+                "trigger_type": job_row.get("trigger_type"),
+                "pause_status": "PAUSED" if job_row.get("paused") else "UNPAUSED",
+            },
+            "cluster_config": {"type": "unavailable"},
+            "task_config": {"type": "unavailable"},
+            "tasks": [{"task_key": k} for k in task_keys],
+            "task_summary": f"{len(task_keys)} task(s) - names only, full config unavailable",
+            "timeout_seconds": job_row.get("timeout_seconds"),
+            "max_concurrent_runs": None,
+            "email_notifications": {},
+            "webhook_notifications": {},
+            "access_control_list": [],
+            "partial": True,
+            "partial_reason": (
+                "Direct Jobs API call failed for this job_id (likely an ACL "
+                "visibility gap - this MCP connection lacks CAN_VIEW on the "
+                "job; see de-repo-artifact#90 for the real fix). Showing "
+                "metadata reconstructed from system.lakeflow.jobs/job_tasks "
+                "instead: name, schedule/trigger type, task keys, and "
+                "run_as/creator. Full cluster spec, task parameters, and "
+                "notebook/script paths are not available this way."
+            ),
+        }
 
     def get_job_runs(
         self, job_id: int, limit: int = 10, active_only: bool = False

--- a/src/mcp_server/mcp_server.py
+++ b/src/mcp_server/mcp_server.py
@@ -728,18 +728,27 @@ def _get_job_details(job_id: int, workspace: Optional[str] = None) -> str:
 
         # Format for AI consumption
         result = f"Job Details for ID {job_id}:\n\n"
+        if details.get("partial"):
+            result += (
+                f"⚠️ **Partial results**: {details['partial_reason']}\n\n"
+            )
         result += f"**Name**: {details['name']}\n"
         result += f"**Type**: {details['job_type']}\n"
         result += f"**Creator**: {details['creator']}\n"
+        if details.get("run_as"):
+            result += f"**Run As**: {details['run_as']}\n"
         result += f"**Created**: {details['created_time']}\n"
-        result += f"**Timeout**: {details.get('timeout_seconds', 'No limit')} seconds\n"
-        result += f"**Max Concurrent Runs**: {details['max_concurrent_runs']}\n\n"
+        result += f"**Timeout**: {details.get('timeout_seconds') or 'No limit'} seconds\n"
+        result += f"**Max Concurrent Runs**: {details.get('max_concurrent_runs') or 'Unknown'}\n\n"
 
         if details["schedule"]:
             schedule = details["schedule"]
             result += f"**Schedule**:\n"
-            result += f"- Cron: {schedule.get('quartz_cron_expression', 'None')}\n"
-            result += f"- Timezone: {schedule.get('timezone_id', 'UTC')}\n"
+            if "quartz_cron_expression" in schedule:
+                result += f"- Cron: {schedule.get('quartz_cron_expression', 'None')}\n"
+                result += f"- Timezone: {schedule.get('timezone_id', 'UTC')}\n"
+            elif schedule.get("trigger_type"):
+                result += f"- Trigger Type: {schedule['trigger_type']}\n"
             result += f"- Status: {schedule.get('pause_status', 'UNPAUSED')}\n\n"
 
         cluster_config = details["cluster_config"]

--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -321,6 +321,120 @@ class TestDatabricksJobManager:
             "DATABRICKS_TOKEN": "test-token",
         },
     )
+    @patch("src.mcp_server.job_manager.get_pool")
+    @patch("src.mcp_server.job_manager.PooledConnection")
+    @patch("src.mcp_server.job_manager.requests.Session")
+    @patch("src.mcp_server.job_manager.log_databricks_event")
+    def test_get_job_details_falls_back_to_system_tables_on_acl_gap(
+        self, mock_log, mock_session_cls, mock_pooled_conn, mock_get_pool
+    ):
+        """
+        When /jobs/get 400s with "does not exist" (de-repo-artifact#89/#90 -
+        this MCP connection lacks CAN_VIEW on the job), get_job_details should
+        recover partial info from system.lakeflow instead of raising.
+        """
+        mock_session = Mock()
+        mock_session_cls.return_value = mock_session
+
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.text = '{"error_code":"RESOURCE_DOES_NOT_EXIST","message":"Job 555 does not exist."}'
+        mock_response.content = mock_response.text.encode()
+        mock_session.request.return_value = mock_response
+
+        mock_conn = Mock()
+        mock_pooled_conn.return_value.__enter__.return_value = mock_conn
+        mock_pooled_conn.return_value.__exit__.return_value = None
+
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.description = [
+            ("name",),
+            ("creator_id",),
+            ("creator_user_name",),
+            ("run_as",),
+            ("run_as_user_name",),
+            ("trigger_type",),
+            ("paused",),
+            ("timeout_seconds",),
+            ("create_time",),
+        ]
+        mock_cursor.fetchone.return_value = (
+            "Ungoverned Click-Ops Job",
+            "creator-sp-id",
+            "someone@hingehealth.com",
+            "run-as-sp-id",
+            "svc-principal@hingehealth.com",
+            "PERIODIC",
+            False,
+            3600,
+            "2026-01-01 00:00:00",
+        )
+        mock_cursor.fetchall.return_value = [("task_a",), ("task_b",)]
+
+        manager = DatabricksJobManager(
+            host="test-workspace.cloud.databricks.com", token="test-token"
+        )
+        details = manager.get_job_details(555)
+
+        assert details["partial"] is True
+        assert "does not exist" not in details["partial_reason"].lower()
+        assert details["name"] == "Ungoverned Click-Ops Job"
+        assert details["creator"] == "someone@hingehealth.com"
+        assert details["run_as"] == "svc-principal@hingehealth.com"
+        assert details["schedule"]["trigger_type"] == "PERIODIC"
+        assert {t["task_key"] for t in details["tasks"]} == {"task_a", "task_b"}
+        assert details["cluster_config"]["type"] == "unavailable"
+
+    @patch.dict(
+        "os.environ",
+        {
+            "DATABRICKS_HOST": "test-workspace.cloud.databricks.com",
+            "DATABRICKS_TOKEN": "test-token",
+        },
+    )
+    @patch("src.mcp_server.job_manager.get_pool")
+    @patch("src.mcp_server.job_manager.PooledConnection")
+    @patch("src.mcp_server.job_manager.requests.Session")
+    @patch("src.mcp_server.job_manager.log_databricks_event")
+    def test_get_job_details_raises_when_truly_missing(
+        self, mock_log, mock_session_cls, mock_pooled_conn, mock_get_pool
+    ):
+        """
+        A job_id that's genuinely missing (not just ACL-gapped) should still
+        raise - the system.lakeflow fallback finds nothing, so the original
+        error propagates instead of being swallowed.
+        """
+        mock_session = Mock()
+        mock_session_cls.return_value = mock_session
+
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.text = '{"error_code":"RESOURCE_DOES_NOT_EXIST","message":"Job 999999 does not exist."}'
+        mock_response.content = mock_response.text.encode()
+        mock_session.request.return_value = mock_response
+
+        mock_conn = Mock()
+        mock_pooled_conn.return_value.__enter__.return_value = mock_conn
+        mock_pooled_conn.return_value.__exit__.return_value = None
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = None
+
+        manager = DatabricksJobManager(
+            host="test-workspace.cloud.databricks.com", token="test-token"
+        )
+
+        with pytest.raises(ValueError, match="does not exist"):
+            manager.get_job_details(999999)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "DATABRICKS_HOST": "test-workspace.cloud.databricks.com",
+            "DATABRICKS_TOKEN": "test-token",
+        },
+    )
     @patch("src.mcp_server.job_manager.requests.Session")
     @patch("src.mcp_server.job_manager.log_databricks_event")
     def test_trigger_job_success(self, mock_log, mock_session_cls):


### PR DESCRIPTION
## Summary

- `/jobs/get` returns the same 400 "does not exist" for a truly missing job and for one this connection's identity can't see (lacks `CAN_VIEW`) - indistinguishable from the error alone.
- `get_job_details` now falls back to `system.lakeflow.jobs`/`job_tasks` in that case, returning partial info (name, creator/`run_as`, trigger type, task keys) marked `partial: True` with an explanation, instead of erroring out with nothing.
- Genuinely missing `job_id`s still raise as before - the fallback only kicks in when the system tables actually have a row.
- `databricks_get_job_details` MCP tool output now surfaces a `⚠️ Partial results` note and `Run As` field when this path is hit.

Implements option 3 from hinge-health/de-repo-artifact#90 (options 1/2 - granting the MCP's identity workspace-wide `CAN_VIEW` via Terraform - are an infra change outside this repo's scope).

## Test plan

- [x] `uv run pytest` - 134/134 pass, including 2 new tests: fallback recovers partial info on ACL-gap, still raises for a genuinely missing job_id
- [x] `uv run mypy src/mcp_server/job_manager.py` - no new errors introduced
- [x] Verified `system.lakeflow.jobs`/`job_tasks` schema live against a real workspace before writing the fallback query