### PR TITLE
chore: fix black formatting drift and mypy no-any-return error

### DIFF
--- a/src/mcp_server/api_client.py
+++ b/src/mcp_server/api_client.py
@@ -79,9 +79,7 @@ class DatabricksAPIClient:
             # retryable — bad input won't succeed on retry and should not
             # trip the circuit breaker.
             if response.status_code < 500:
-                raise ValueError(
-                    f"client error: HTTP {response.status_code}: {body}"
-                )
+                raise ValueError(f"client error: HTTP {response.status_code}: {body}")
             raise Exception(
                 f"databricks api error: HTTP {response.status_code}: {body}"
             )

--- a/src/mcp_server/error_handler.py
+++ b/src/mcp_server/error_handler.py
@@ -176,23 +176,36 @@ class ErrorHandler:
 
         # Check rate limit FIRST — rate limit messages can contain "token" (e.g. "token bucket")
         # which would false-match the auth check below if order were reversed.
-        if any(keyword in error_str for keyword in ["rate limit", "too many requests", "429", "throttl"]):
+        if any(
+            keyword in error_str
+            for keyword in ["rate limit", "too many requests", "429", "throttl"]
+        ):
             return ErrorType.RATE_LIMIT
 
-        if any(keyword in error_str for keyword in ["authentication", "unauthorized", "forbidden"]):
+        if any(
+            keyword in error_str
+            for keyword in ["authentication", "unauthorized", "forbidden"]
+        ):
             return ErrorType.AUTHENTICATION
 
         # Narrow token match: only treat as auth when paired with a failure qualifier.
-        if "token" in error_str and any(keyword in error_str for keyword in ["expired", "invalid", "revoked"]):
+        if "token" in error_str and any(
+            keyword in error_str for keyword in ["expired", "invalid", "revoked"]
+        ):
             return ErrorType.AUTHENTICATION
 
         if "timeout" in error_str:
             return ErrorType.TIMEOUT
 
-        if any(keyword in error_str for keyword in ["network", "connection", "unreachable", "refused", "reset"]):
+        if any(
+            keyword in error_str
+            for keyword in ["network", "connection", "unreachable", "refused", "reset"]
+        ):
             return ErrorType.NETWORK
 
-        if any(keyword in error_str for keyword in ["databricks", "api error", "rest api"]):
+        if any(
+            keyword in error_str for keyword in ["databricks", "api error", "rest api"]
+        ):
             return ErrorType.DATABRICKS_API
 
         if any(keyword in error_str for keyword in ["sql", "query", "syntax"]):

--- a/src/mcp_server/genie_manager.py
+++ b/src/mcp_server/genie_manager.py
@@ -157,8 +157,9 @@ def _list_spaces(workspace: Optional[str] = None) -> str:
             desc = (s.get("description", "") or "")[:100]
             rows.append(f"| {sid} | {title} | {desc} |")
 
-        result = f"Genie Spaces ({len(spaces)} found):\n\n{header}\n{sep}\n" + "\n".join(
-            rows
+        result = (
+            f"Genie Spaces ({len(spaces)} found):\n\n{header}\n{sep}\n"
+            + "\n".join(rows)
         )
         return enforce_character_limit(result)
     except Exception as e:
@@ -364,9 +365,7 @@ def _ask_question(
             )
 
         if status not in ("COMPLETED", "FAILED", "CANCELLED"):
-            msg = _genie_poll_message(
-                client, space_id, msg_conversation_id, message_id
-            )
+            msg = _genie_poll_message(client, space_id, msg_conversation_id, message_id)
         else:
             msg = resp.get("message", resp)
 
@@ -390,8 +389,7 @@ def _ask_question(
                             manifest = stmt.get("manifest", {})
                             columns = manifest.get("schema", {}).get("columns", [])
                             col_names = [
-                                c.get("name", f"col_{i}")
-                                for i, c in enumerate(columns)
+                                c.get("name", f"col_{i}") for i, c in enumerate(columns)
                             ]
                             data_array = stmt.get("result", {}).get("data_array", [])
 
@@ -413,15 +411,15 @@ def _ask_question(
                                 total = stmt.get("result", {}).get(
                                     "row_count", row_count
                                 )
-                                formatted += f"\n_Showing {row_count} of {total} total rows._\n"
+                                formatted += (
+                                    f"\n_Showing {row_count} of {total} total rows._\n"
+                                )
                             else:
                                 formatted += "\n_Query returned no rows._\n"
                         elif result_status == "RUNNING":
                             formatted += "\n_Query is still executing. Use `databricks_genie_get_query_result` to retrieve results later._\n"
                     except Exception as qe:
-                        formatted += (
-                            f"\n_Could not fetch query results: {qe}_\n"
-                        )
+                        formatted += f"\n_Could not fetch query results: {qe}_\n"
 
         return enforce_character_limit(formatted)
     except Exception as e:

--- a/src/mcp_server/job_manager.py
+++ b/src/mcp_server/job_manager.py
@@ -222,7 +222,9 @@ class DatabricksJobManager:
                     last_run_time = None
                     if "last_run" in job_data:
                         last_run = job_data["last_run"]
-                        last_run_state = last_run.get("state", {}).get("life_cycle_state")
+                        last_run_state = last_run.get("state", {}).get(
+                            "life_cycle_state"
+                        )
                         last_run_time = last_run.get("start_time")
 
                     job_info = JobInfo(
@@ -321,7 +323,9 @@ class DatabricksJobManager:
             )
             raise
 
-    def _get_job_details_from_system_tables(self, job_id: int) -> Optional[Dict[str, Any]]:
+    def _get_job_details_from_system_tables(
+        self, job_id: int
+    ) -> Optional[Dict[str, Any]]:
         """
         Best-effort fallback when /jobs/get 400s with "does not exist".
 
@@ -386,7 +390,9 @@ class DatabricksJobManager:
             "job_id": job_id,
             "name": job_row.get("name") or f"Job {job_id}",
             "created_time": str(create_time) if create_time else "Unknown",
-            "creator": job_row.get("creator_user_name") or job_row.get("creator_id") or "unknown",
+            "creator": job_row.get("creator_user_name")
+            or job_row.get("creator_id")
+            or "unknown",
             "run_as": job_row.get("run_as_user_name") or job_row.get("run_as"),
             "job_type": "multi_task" if len(task_keys) > 1 else "single_task",
             "schedule": {
@@ -746,7 +752,10 @@ class DatabricksJobManager:
 
     def get_job_run_details(self, run_id: int) -> Dict[str, Any]:
         """Get full run details (metadata + cluster info) for diagnostics."""
-        return self._make_request("GET", "/jobs/runs/get", params={"run_id": run_id})
+        result: Dict[str, Any] = self._make_request(
+            "GET", "/jobs/runs/get", params={"run_id": run_id}
+        )
+        return result
 
     def _format_timestamp(self, timestamp_ms: int) -> str:
         """Format timestamp for human readability."""

--- a/src/mcp_server/mcp_server.py
+++ b/src/mcp_server/mcp_server.py
@@ -648,7 +648,11 @@ def _list_jobs(
         )
 
         if not all_jobs:
-            msg = f"No jobs found matching '{name_filter}'." if name_filter else "No jobs found in the Databricks workspace."
+            msg = (
+                f"No jobs found matching '{name_filter}'."
+                if name_filter
+                else "No jobs found in the Databricks workspace."
+            )
             return msg + truncation_notice
 
         total = len(all_jobs)
@@ -729,16 +733,16 @@ def _get_job_details(job_id: int, workspace: Optional[str] = None) -> str:
         # Format for AI consumption
         result = f"Job Details for ID {job_id}:\n\n"
         if details.get("partial"):
-            result += (
-                f"⚠️ **Partial results**: {details['partial_reason']}\n\n"
-            )
+            result += f"⚠️ **Partial results**: {details['partial_reason']}\n\n"
         result += f"**Name**: {details['name']}\n"
         result += f"**Type**: {details['job_type']}\n"
         result += f"**Creator**: {details['creator']}\n"
         if details.get("run_as"):
             result += f"**Run As**: {details['run_as']}\n"
         result += f"**Created**: {details['created_time']}\n"
-        result += f"**Timeout**: {details.get('timeout_seconds') or 'No limit'} seconds\n"
+        result += (
+            f"**Timeout**: {details.get('timeout_seconds') or 'No limit'} seconds\n"
+        )
         result += f"**Max Concurrent Runs**: {details.get('max_concurrent_runs') or 'Unknown'}\n\n"
 
         if details["schedule"]:
@@ -1617,7 +1621,9 @@ def _get_job_run_logs(
                 result += f"### Driver Logs (excerpt)\n\n```\n{logs}\n```\n\n"
 
             if not any([error, error_trace, logs, notebook_output]):
-                result += "_No output, errors, or logs returned by the run output API._\n\n"
+                result += (
+                    "_No output, errors, or logs returned by the run output API._\n\n"
+                )
         except Exception as oe:
             result += f"_Could not fetch run output: {oe}_\n\n"
 

--- a/tests/test_error_classification.py
+++ b/tests/test_error_classification.py
@@ -1,4 +1,5 @@
 """Tests for error classification edge cases in ErrorHandler."""
+
 from __future__ import annotations
 
 from mcp_server.error_handler import ErrorHandler, ErrorType

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,4 +1,5 @@
 """Test circuit breaker and retry logic."""
+
 from __future__ import annotations
 
 import time
@@ -40,7 +41,9 @@ def test_circuit_breaker_transitions_to_half_open():
 
 
 def test_circuit_breaker_closes_after_success_threshold():
-    config = CircuitBreakerConfig(failure_threshold=1, recovery_timeout_seconds=0.1, success_threshold=2)
+    config = CircuitBreakerConfig(
+        failure_threshold=1, recovery_timeout_seconds=0.1, success_threshold=2
+    )
     cb = CircuitBreaker("test", config)
     cb.record_failure()
     time.sleep(0.15)
@@ -75,7 +78,11 @@ def test_retry_decorator_retries_on_retryable():
     handler = ErrorHandler()
     call_count = 0
 
-    @handler.with_retry("test_retry", RetryConfig(max_attempts=3, base_delay_seconds=0.01), circuit_breaker=False)
+    @handler.with_retry(
+        "test_retry",
+        RetryConfig(max_attempts=3, base_delay_seconds=0.01),
+        circuit_breaker=False,
+    )
     def flaky():
         nonlocal call_count
         call_count += 1
@@ -92,7 +99,9 @@ def test_retry_skips_non_retryable():
     handler = ErrorHandler()
     call_count = 0
 
-    @handler.with_retry("test_no_retry", RetryConfig(max_attempts=3), circuit_breaker=False)
+    @handler.with_retry(
+        "test_no_retry", RetryConfig(max_attempts=3), circuit_breaker=False
+    )
     def fail_auth():
         nonlocal call_count
         call_count += 1

--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -178,7 +178,9 @@ class TestDatabricksJobManager:
     )
     @patch("src.mcp_server.job_manager.requests.Session")
     @patch("src.mcp_server.job_manager.log_databricks_event")
-    def test_list_jobs_reports_truncation_at_safety_cap(self, mock_log, mock_session_cls):
+    def test_list_jobs_reports_truncation_at_safety_cap(
+        self, mock_log, mock_session_cls
+    ):
         """If the safety cap is hit before has_more is False, callers must be told."""
         mock_session = Mock()
         mock_session_cls.return_value = mock_session

--- a/tests/test_sql_safety.py
+++ b/tests/test_sql_safety.py
@@ -1,4 +1,5 @@
 """Test SQL identifier validation and read-only detection."""
+
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Summary
- \`black --check\` was failing on 9 files (pre-existing drift, not caught by CI since this repo's CI doesn't run black)
- \`mypy\` had one \`no-any-return\` error in \`get_job_run_details()\` — the \`@with_databricks_retry\` decorator's generic \`Callable[..., Any]\` signature erases \`_make_request\`'s declared \`Dict[str, Any]\` return type, so returning it directly trips the check

Found while grooming the de-mcp-hub mirror for a public rollout — wanted this repo (the actual source of truth) clean before propagating.

## Test plan
- [x] \`black --check src tests\` — clean
- [x] \`mypy src/mcp_server/ --ignore-missing-imports\` — no issues
- [x] \`pytest tests/\` — 134 passed

Generated with [Claude Code](https://claude.com/claude-code)